### PR TITLE
chore: update url in header

### DIFF
--- a/lib/riveter.js
+++ b/lib/riveter.js
@@ -4,7 +4,7 @@
  * © 2019 - Copyright Zach Lintz, LLC
  * Author(s): Jim Cowart, Nicholas Cloud, Doug Neiner, Zach Lintz
  * Version: v0.2.1
- * Url: https://github.com/zlintz/riveter
+ * Url: https://github.com/Foo-Foo-MQ/node-riveter
  * License(s): MIT, GPL
  */
 


### PR DESCRIPTION
This repo seems to have been moved from `https://github.com/zlintz/riveter` to `https://github.com/Foo-Foo-MQ/node-riveter`.

This PR simply updates the URL in the header of `lib/riveter.js `.